### PR TITLE
Fix for arrayborrow and recordborrow bytecodes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>org.whiley</groupId>
       <artifactId>wyc</artifactId>
-      <version>0.5.0</version>
+      <version>0.5.3</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/src/main/java/wy2boogie/translate/Wyil2Boogie.java
+++ b/src/main/java/wy2boogie/translate/Wyil2Boogie.java
@@ -1353,6 +1353,7 @@ public final class Wyil2Boogie {
 		case EXPR_arraylength:
 			return boogieArrayLength((Expr.ArrayLength) expr);
 
+		case EXPR_arrayborrow:
 		case EXPR_arrayaccess:
 			return boogieArrayIndex((Expr.ArrayAccess) expr);
 
@@ -1372,6 +1373,7 @@ public final class Wyil2Boogie {
 			final Expr.Constant c = (Expr.Constant) expr;
 			return createConstant(c.getValue());
 
+		case EXPR_recordborrow:
 		case EXPR_recordaccess:
 			return boogieFieldLoad((Expr.RecordAccess) expr);
 


### PR DESCRIPTION
The two bytecodes EXPR_arrayborrow and EXPR_recordborrow have been added
to help with implementing value semantics on different backends.  They
may or may not be kept long term, as I have discovered potentially
better ways to do it.

This fix simply updates the Boogie translator to be aware of these
bytecodes.  For our purposes here, they can be just treated as identical
to the equivalent EXPR_arrayaccess and EXPR_recordaccess bytecodes.